### PR TITLE
allow empty DOCKER_DOMAIN_SUFFIX

### DIFF
--- a/m4/arg_with_define_string.m4
+++ b/m4/arg_with_define_string.m4
@@ -12,7 +12,7 @@
 AC_DEFUN([ACX_ARG_WITH_DEFINE_STRING], [
     AC_MSG_CHECKING([$2])
     AC_ARG_WITH([$1], [AS_HELP_STRING([--with-$1=$3], [$2])])
-    AS_VAR_IF(AS_TR_SH([with_$1]), [], [
+    AS_VAR_SET_IF(AS_TR_SH([with_$1]), [], [
         AC_CACHE_VAL(AS_TR_SH([acx_cv_arg_with_$1]), [
             AS_VAR_SET(AS_TR_SH([acx_cv_arg_with_$1]), [$3])])
         AS_VAR_COPY(AS_TR_SH([with_$1]), AS_TR_SH([acx_cv_arg_with_$1]))])


### PR DESCRIPTION
This patch allows complete removal of DOCKER_DOMAIN_SUFFIX during configuration phase, like this:
`./configure --prefix=/usr --with-docker-domain-suffix=""`

So instead of `ping test.docker` you can do just `ping test`, just like you would inside of the container.