### PR TITLE
Use 102400B for message buffer

### DIFF
--- a/src/libnss_docker.c
+++ b/src/libnss_docker.c
@@ -101,7 +101,7 @@ enum nss_status _nss_docker_gethostbyname3_r(
     size_t req_message_len;
 
     /* response message buffer */
-    char res_message_buffer[10240];
+    char res_message_buffer[102400];
 
     /* response message size */
     size_t res_message_len;


### PR DESCRIPTION
It's not uncommon for containers to have more metadata than ~10K