### PR TITLE
Allow optional plain hostnames (no FQDN)

### DIFF
--- a/src/libnss_docker.c
+++ b/src/libnss_docker.c
@@ -162,18 +162,21 @@ enum nss_status _nss_docker_gethostbyname3_r(
     strncpy(hostname, name, sizeof(hostname));
     hostname[name_len] = '\0';
 
-    /* Handle only .docker domain */
-    if ((hostname_suffix_ptr = strstr(hostname, DOCKER_DOMAIN_SUFFIX)) == NULL) {
-        *errnop = EADDRNOTAVAIL;
-        goto return_unavail;
-    }
+    /* Hostnames without domain names don't need truncation. */
+    if (strstr(hostname, ".") != NULL) {
+        /* Handle docker domain suffix (.docker by default, but ./configure can override) */
+        if ((hostname_suffix_ptr = strstr(hostname, DOCKER_DOMAIN_SUFFIX)) == NULL) {
+            *errnop = EADDRNOTAVAIL;
+            goto return_unavail;
+        }
 
-    if (hostname_suffix_ptr[sizeof(DOCKER_DOMAIN_SUFFIX) - 1] != '\0') {
-        *errnop = EADDRNOTAVAIL;
-        goto return_unavail;
-    }
+        if (hostname_suffix_ptr[sizeof(DOCKER_DOMAIN_SUFFIX) - 1] != '\0') {
+            *errnop = EADDRNOTAVAIL;
+            goto return_unavail;
+        }
 
-    *hostname_suffix_ptr = '\0';
+        *hostname_suffix_ptr = '\0';
+    }
 
     /* Connect to Docker API socket */
     memset((char *) &docker_api_addr, 0, sizeof(docker_api_addr));


### PR DESCRIPTION
I have a use case where I really need plain host names, with no ".docker" suffix. We have a container running an SSO IDP, another container with a web server as an SSO SP, and a third container running webdriver tests. The issue is that SAML2 is quite fussy about host names, and each host needs a known host name. When developing on the host machine, testing in the host machines web browser and testing using webdriver on the host, you currently need the ".docker" extension. However, when testing within the webdriver container (as is the case when running GitHub Actions automated on-checkin testing) requires no ".docker" extension. Life would be so much easier if the host could know the container names without the suffix.

I see another user has created a pull request to allow DOCKER_DOMAIN_SUFFIX to be an empty string at compile time. That could work, but seems a bit of a hack, plus will never be the default configuration on a distro installed package. This configuration more mirrors what users expect DNS resolution to look like. When initially installing the package (and not reading the documentation), I expected to be able to use plain hostnames, and had to google to find out about the ".docker" suffix. I believe this patch fixes that usability issue.