### PR TITLE
Increase size of response message buffer

### DIFF
--- a/src/libnss_docker.c
+++ b/src/libnss_docker.c
@@ -101,7 +101,7 @@ enum nss_status _nss_docker_gethostbyname3_r(
     size_t req_message_len;
 
     /* response message buffer */
-    char res_message_buffer[10240];
+    char res_message_buffer[20480];
 
     /* response message size */
     size_t res_message_len;


### PR DESCRIPTION
We were experiencing a lack of function due to an overly long 'output' element coupled with quite a few overlay mounts, which lead to the buffer not even containing the network section.

A simple doubling in buffer size fixes this problem, but since the container information can be arbitrarily long, this is just a jury-rigged fix.

My C isn't good enough to formulate a better plan for this (some kind of response paging, maybe even properly parsing the JSON?) and rewriting it as a search over all networks seems a bit overkill.